### PR TITLE
VoiceChannel の移動をしていなくても TextChannel を入退室するバグを修正

### DIFF
--- a/internal/application/voicetext/service.go
+++ b/internal/application/voicetext/service.go
@@ -29,7 +29,7 @@ func NewVoiceTextService(
 }
 
 func (s *Service) VoiceStateUpdate(ctx context.Context, cmd VoiceStateUpdateCommand) error {
-	if cmd.BeforeVoiceChannelID == cmd.AfterVoiceChannelID {
+	if *cmd.BeforeVoiceChannelID == *cmd.AfterVoiceChannelID {
 		return nil
 	}
 


### PR DESCRIPTION
# 原因

- string の比較をすべきところで *string の比較をしていた

# 対応

- デリファレンスして比較するようにした
