### PR TITLE
カスタムステータスで実行中のバージョンを表示する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build for ARM64 (Linux)
         run: |
-          GOOS=linux GOARCH=arm64 go build -o discord-bot-linux-arm64 ./cmd/bot
+          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=${{ steps.determine_tag.outputs.tag }}" -o discord-bot-linux-arm64 ./cmd/bot
         env:
           CGO_ENABLED: 0
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -29,6 +29,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// version はボットのバージョン情報を保持します。
+// ビルド時に ldflags で上書き可能です: go build -ldflags "-X main.version=v1.0.0"
+// デフォルトは "develop" です。
+var version = "develop"
+
 func main() {
 	ctx := context.Background()
 	cfg := config.Load()
@@ -108,6 +113,9 @@ func main() {
 
 	if err := session.Open(); err != nil {
 		log.Fatalf("cannot open Discord session: %v", err)
+	}
+	if err := session.UpdateCustomStatus(version); err != nil {
+		log.Printf("failed to update bot status: %v", err)
 	}
 	defer session.Close()
 


### PR DESCRIPTION
# やったこと

- カスタムステータスで実行中の bot のバージョンを表示する
- 開発環境や version 情報を指定せずにビルドした場合は `develop` と表示する