### PR TITLE
fix: Watchtower の Docker API バージョンを明示的に指定して起動エラーを修正

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -32,6 +32,8 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DOCKER_API_VERSION=1.41
     command: --label-enable --interval 300 --cleanup
 
   portainer:


### PR DESCRIPTION
## 概要

`containrrr/watchtower` が以下のエラーで起動に失敗し、restart ループに陥っていた問題を修正。

```
Error response from daemon: client version 1.25 is too old. Minimum supported API version is 1.40
```

## 原因

ホストの `DOCKER_API_VERSION` 環境変数が `1.25` に設定されており、Watchtower コンテナに継承されていた。

## 修正内容

`docker-compose.deploy.yml` の `watchtower` サービスに `DOCKER_API_VERSION=1.41` を明示的に指定し、ホストの環境変数を上書きするようにした。

## テスト

- [ ] サーバーで `docker compose -f docker-compose.deploy.yml up -d watchtower` を実行して起動確認
- [ ] Watchtower が新しいイメージを検出・デプロイすることを確認

🤖 Generated with Claude Code