### PR TITLE
fix: VoiceStateUpdateのnilポインタ逆参照バグを修正

### DIFF
--- a/internal/application/voicetext/service.go
+++ b/internal/application/voicetext/service.go
@@ -29,7 +29,11 @@ func NewVoiceTextService(
 }
 
 func (s *Service) VoiceStateUpdate(ctx context.Context, cmd VoiceStateUpdateCommand) error {
-	if *cmd.BeforeVoiceChannelID == *cmd.AfterVoiceChannelID {
+	if cmd.BeforeVoiceChannelID == nil && cmd.AfterVoiceChannelID == nil {
+		return nil
+	}
+	if cmd.BeforeVoiceChannelID != nil && cmd.AfterVoiceChannelID != nil &&
+		*cmd.BeforeVoiceChannelID == *cmd.AfterVoiceChannelID {
 		return nil
 	}
 


### PR DESCRIPTION
BeforeVoiceChannelID / AfterVoiceChannelID はポインタ型だが、
nilチェックより先にデリファレンスしていたためパニックが発生する恐れがあった。
両方nilの場合と両方同じチャンネルを指す場合に早期リターンするよう修正。

https://claude.ai/code/session_01Fr94DdYKyp1NkYEAMhtKcY