### PR TITLE
refactor: 伝説コマンドの重複を legend パッケージに集約

### DIFF
--- a/internal/application/faker/service.go
+++ b/internal/application/faker/service.go
@@ -3,7 +3,8 @@ package faker
 import (
 	"context"
 
-	"github.com/aktnb/discord-bot-go/internal/domain/faker"
+	domainfaker "github.com/aktnb/discord-bot-go/internal/domain/faker"
+	"github.com/aktnb/discord-bot-go/internal/domain/legend"
 )
 
 type Service struct{}
@@ -12,7 +13,6 @@ func NewFakerService() *Service {
 	return &Service{}
 }
 
-// GetRandomEpisode は Faker の伝説エピソードをランダムに1つ返す
-func (s *Service) GetRandomEpisode(ctx context.Context) (faker.Episode, error) {
-	return faker.RandomEpisode(), nil
+func (s *Service) GetRandomEpisode(ctx context.Context) (legend.Episode, error) {
+	return domainfaker.RandomEpisode(), nil
 }

--- a/internal/application/ichiro/service.go
+++ b/internal/application/ichiro/service.go
@@ -3,7 +3,8 @@ package ichiro
 import (
 	"context"
 
-	"github.com/aktnb/discord-bot-go/internal/domain/ichiro"
+	domainiichiro "github.com/aktnb/discord-bot-go/internal/domain/ichiro"
+	"github.com/aktnb/discord-bot-go/internal/domain/legend"
 )
 
 type Service struct{}
@@ -12,7 +13,6 @@ func NewIchiroService() *Service {
 	return &Service{}
 }
 
-// GetRandomEpisode は全盛期のイチロー伝説エピソードをランダムに1つ返す
-func (s *Service) GetRandomEpisode(ctx context.Context) (ichiro.Episode, error) {
-	return ichiro.RandomEpisode(), nil
+func (s *Service) GetRandomEpisode(ctx context.Context) (legend.Episode, error) {
+	return domainiichiro.RandomEpisode(), nil
 }

--- a/internal/application/jeffdean/service.go
+++ b/internal/application/jeffdean/service.go
@@ -3,7 +3,8 @@ package jeffdean
 import (
 	"context"
 
-	"github.com/aktnb/discord-bot-go/internal/domain/jeffdean"
+	domainjeffdean "github.com/aktnb/discord-bot-go/internal/domain/jeffdean"
+	"github.com/aktnb/discord-bot-go/internal/domain/legend"
 )
 
 type Service struct{}
@@ -12,7 +13,6 @@ func NewJeffDeanService() *Service {
 	return &Service{}
 }
 
-// GetRandomFact は Jeff Dean の伝説をランダムに1つ返す
-func (s *Service) GetRandomFact(ctx context.Context) (jeffdean.Fact, error) {
-	return jeffdean.RandomFact(), nil
+func (s *Service) GetRandomFact(ctx context.Context) (legend.Episode, error) {
+	return domainjeffdean.RandomFact(), nil
 }

--- a/internal/domain/faker/model.go
+++ b/internal/domain/faker/model.go
@@ -1,12 +1,6 @@
 package faker
 
-import "math/rand/v2"
-
-// Episode は Faker の伝説エピソード
-type Episode struct {
-	Number int
-	Text   string
-}
+import "github.com/aktnb/discord-bot-go/internal/domain/legend"
 
 // episodes は Faker の伝説エピソード一覧
 var episodes = []string{
@@ -37,10 +31,6 @@ var episodes = []string{
 }
 
 // RandomEpisode はエピソードをランダムに1つ返す
-func RandomEpisode() Episode {
-	i := rand.IntN(len(episodes))
-	return Episode{
-		Number: i + 1,
-		Text:   episodes[i],
-	}
+func RandomEpisode() legend.Episode {
+	return legend.Random(episodes)
 }

--- a/internal/domain/ichiro/model.go
+++ b/internal/domain/ichiro/model.go
@@ -1,12 +1,6 @@
 package ichiro
 
-import "math/rand/v2"
-
-// Episode は全盛期のイチロー伝説エピソード
-type Episode struct {
-	Number int
-	Text   string
-}
+import "github.com/aktnb/discord-bot-go/internal/domain/legend"
 
 // episodes は全盛期のイチロー伝説エピソード一覧
 var episodes = []string{
@@ -31,10 +25,6 @@ var episodes = []string{
 }
 
 // RandomEpisode はエピソードをランダムに1つ返す
-func RandomEpisode() Episode {
-	i := rand.IntN(len(episodes))
-	return Episode{
-		Number: i + 1,
-		Text:   episodes[i],
-	}
+func RandomEpisode() legend.Episode {
+	return legend.Random(episodes)
 }

--- a/internal/domain/jeffdean/model.go
+++ b/internal/domain/jeffdean/model.go
@@ -1,12 +1,6 @@
 package jeffdean
 
-import "math/rand/v2"
-
-// Fact は Jeff Dean の伝説
-type Fact struct {
-	Number int
-	Text   string
-}
+import "github.com/aktnb/discord-bot-go/internal/domain/legend"
 
 // facts は Jeff Dean の伝説一覧
 var facts = []string{
@@ -33,7 +27,7 @@ var facts = []string{
 	"Jeff DeanのバブルソートプログラムはO(1)で動作する。",
 	"Jeff Deanはあるときbitをあまりにもshiftしすぎたため、最後には隣のマシンに移動してしまった。",
 	`gccの最適化オプション
-> gcc -O1: コンパイラは、 コードのサイズと実行時間を削減するよう試みます。 
+> gcc -O1: コンパイラは、 コードのサイズと実行時間を削減するよう試みます。
 > gcc -O2: さらに最適化を行います。
 > gcc -O3: さらに一層、 最適化を行います。
 > gcc -O4: 完全に書きなおしてもらうために、あなたのコードをJeff Deanに送信します。
@@ -69,10 +63,6 @@ var facts = []string{
 }
 
 // RandomFact は伝説をランダムに1つ返す
-func RandomFact() Fact {
-	i := rand.IntN(len(facts))
-	return Fact{
-		Number: i + 1,
-		Text:   facts[i],
-	}
+func RandomFact() legend.Episode {
+	return legend.Random(facts)
 }

--- a/internal/domain/legend/model.go
+++ b/internal/domain/legend/model.go
@@ -1,0 +1,15 @@
+package legend
+
+import "math/rand/v2"
+
+// Episode は伝説エピソード
+type Episode struct {
+	Number int
+	Text   string
+}
+
+// Random はエピソード一覧からランダムに1つ返す
+func Random(episodes []string) Episode {
+	i := rand.IntN(len(episodes))
+	return Episode{Number: i + 1, Text: episodes[i]}
+}

--- a/internal/domain/legend/model_test.go
+++ b/internal/domain/legend/model_test.go
@@ -1,0 +1,18 @@
+package legend
+
+import "testing"
+
+func TestRandom(t *testing.T) {
+	episodes := []string{"aaa", "bbb", "ccc"}
+	ep := Random(episodes)
+
+	if ep.Number < 1 || ep.Number > len(episodes) {
+		t.Errorf("expected number between 1 and %d, got %d", len(episodes), ep.Number)
+	}
+	if ep.Text == "" {
+		t.Error("expected non-empty text")
+	}
+	if episodes[ep.Number-1] != ep.Text {
+		t.Errorf("expected %q at index %d, got %q", episodes[ep.Number-1], ep.Number-1, ep.Text)
+	}
+}

--- a/internal/infrastructure/discord/commands/faker/command.go
+++ b/internal/infrastructure/discord/commands/faker/command.go
@@ -1,52 +1,15 @@
 package faker
 
 import (
-	"context"
-	"fmt"
-	"log"
-
 	appfaker "github.com/aktnb/discord-bot-go/internal/application/faker"
-	"github.com/bwmarrin/discordgo"
+	legendcmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/legend"
 )
 
-type FakerCommand struct {
-	service *appfaker.Service
-}
-
-func NewFakerCommand(service *appfaker.Service) *FakerCommand {
-	return &FakerCommand{
-		service: service,
-	}
-}
-
-func (c *FakerCommand) Name() string {
-	return "faker"
-}
-
-func (c *FakerCommand) ToDiscordCommand() *discordgo.ApplicationCommand {
-	return &discordgo.ApplicationCommand{
-		Name:        c.Name(),
-		Description: "LOL プロプレイヤー Faker の伝説エピソードをランダムに紹介します",
-	}
-}
-
-func (c *FakerCommand) Handle(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate) error {
-	episode, err := c.service.GetRandomEpisode(ctx)
-	if err != nil {
-		log.Printf("Error getting faker episode: %v", err)
-		return err
-	}
-
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("Faker伝説 その%d\n> %s", episode.Number, episode.Text),
-		},
-	})
-	if err != nil {
-		log.Printf("Error responding to faker: %v", err)
-		return err
-	}
-
-	return nil
+func NewFakerCommand(service *appfaker.Service) *legendcmd.Command {
+	return legendcmd.New(
+		"faker",
+		"LOL プロプレイヤー Faker の伝説エピソードをランダムに紹介します",
+		"Faker",
+		service.GetRandomEpisode,
+	)
 }

--- a/internal/infrastructure/discord/commands/ichiro/command.go
+++ b/internal/infrastructure/discord/commands/ichiro/command.go
@@ -1,52 +1,15 @@
 package ichiro
 
 import (
-	"context"
-	"fmt"
-	"log"
-
 	appichiro "github.com/aktnb/discord-bot-go/internal/application/ichiro"
-	"github.com/bwmarrin/discordgo"
+	legendcmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/legend"
 )
 
-type IchiroCommand struct {
-	service *appichiro.Service
-}
-
-func NewIchiroCommand(service *appichiro.Service) *IchiroCommand {
-	return &IchiroCommand{
-		service: service,
-	}
-}
-
-func (c *IchiroCommand) Name() string {
-	return "ichiro"
-}
-
-func (c *IchiroCommand) ToDiscordCommand() *discordgo.ApplicationCommand {
-	return &discordgo.ApplicationCommand{
-		Name:        c.Name(),
-		Description: "全盛期のイチロー伝説をランダムに紹介します",
-	}
-}
-
-func (c *IchiroCommand) Handle(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate) error {
-	episode, err := c.service.GetRandomEpisode(ctx)
-	if err != nil {
-		log.Printf("Error getting ichiro episode: %v", err)
-		return err
-	}
-
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("イチロー伝説 その%d\n> %s", episode.Number, episode.Text),
-		},
-	})
-	if err != nil {
-		log.Printf("Error responding to ichiro: %v", err)
-		return err
-	}
-
-	return nil
+func NewIchiroCommand(service *appichiro.Service) *legendcmd.Command {
+	return legendcmd.New(
+		"ichiro",
+		"全盛期のイチロー伝説をランダムに紹介します",
+		"イチロー",
+		service.GetRandomEpisode,
+	)
 }

--- a/internal/infrastructure/discord/commands/jeffdean/command.go
+++ b/internal/infrastructure/discord/commands/jeffdean/command.go
@@ -1,52 +1,15 @@
 package jeffdean
 
 import (
-	"context"
-	"fmt"
-	"log"
-
 	appjeffdean "github.com/aktnb/discord-bot-go/internal/application/jeffdean"
-	"github.com/bwmarrin/discordgo"
+	legendcmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/legend"
 )
 
-type JeffDeanCommand struct {
-	service *appjeffdean.Service
-}
-
-func NewJeffDeanCommand(service *appjeffdean.Service) *JeffDeanCommand {
-	return &JeffDeanCommand{
-		service: service,
-	}
-}
-
-func (c *JeffDeanCommand) Name() string {
-	return "jeff-dean"
-}
-
-func (c *JeffDeanCommand) ToDiscordCommand() *discordgo.ApplicationCommand {
-	return &discordgo.ApplicationCommand{
-		Name:        c.Name(),
-		Description: "Googleのエンジニア Jeff Dean の伝説をランダムに紹介します",
-	}
-}
-
-func (c *JeffDeanCommand) Handle(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate) error {
-	fact, err := c.service.GetRandomFact(ctx)
-	if err != nil {
-		log.Printf("Error getting jeff-dean fact: %v", err)
-		return err
-	}
-
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{
-			Content: fmt.Sprintf("Jeff Dean伝説 その%d\n> %s", fact.Number, fact.Text),
-		},
-	})
-	if err != nil {
-		log.Printf("Error responding to jeff-dean: %v", err)
-		return err
-	}
-
-	return nil
+func NewJeffDeanCommand(service *appjeffdean.Service) *legendcmd.Command {
+	return legendcmd.New(
+		"jeff-dean",
+		"Googleのエンジニア Jeff Dean の伝説をランダムに紹介します",
+		"Jeff Dean",
+		service.GetRandomFact,
+	)
 }

--- a/internal/infrastructure/discord/commands/legend/command.go
+++ b/internal/infrastructure/discord/commands/legend/command.go
@@ -1,0 +1,61 @@
+package legend
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aktnb/discord-bot-go/internal/domain/legend"
+	"github.com/bwmarrin/discordgo"
+)
+
+type EpisodeGetter func(ctx context.Context) (legend.Episode, error)
+
+// Command はエピソードをランダムに返す伝説コマンドの共通実装
+type Command struct {
+	name        string
+	description string
+	prefix      string
+	getEpisode  EpisodeGetter
+}
+
+func New(name, description, prefix string, getter EpisodeGetter) *Command {
+	return &Command{
+		name:        name,
+		description: description,
+		prefix:      prefix,
+		getEpisode:  getter,
+	}
+}
+
+func (c *Command) Name() string {
+	return c.name
+}
+
+func (c *Command) ToDiscordCommand() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        c.name,
+		Description: c.description,
+	}
+}
+
+func (c *Command) Handle(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	episode, err := c.getEpisode(ctx)
+	if err != nil {
+		log.Printf("Error getting %s episode: %v", c.name, err)
+		return err
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("%s伝説 その%d\n> %s", c.prefix, episode.Number, episode.Text),
+		},
+	})
+	if err != nil {
+		log.Printf("Error responding to %s: %v", c.name, err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- domain/legend: 共有の Episode 型と Random() ヘルパーを追加
- faker/ichiro/jeffdean ドメイン: 独自の Episode/Fact 型を legend.Episode に統一
- アプリケーションサービス: 戻り値型を legend.Episode に更新
- commands/legend: コマンド共通実装 (Command/EpisodeGetter) を追加
- faker/ichiro/jeffdean コマンド: legend.Command への委譲に簡略化

https://claude.ai/code/session_011aGXXxL4RZ3HQ69Rx5d5Do