### PR TITLE
feat: /version コマンドを追加

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aktnb/discord-bot-go/internal/application/mahjong"
 	"github.com/aktnb/discord-bot-go/internal/application/omikuji"
 	"github.com/aktnb/discord-bot-go/internal/application/ping"
+	versionapp "github.com/aktnb/discord-bot-go/internal/application/version"
 	"github.com/aktnb/discord-bot-go/internal/application/voicetext"
 	"github.com/aktnb/discord-bot-go/internal/application/yamada"
 	"github.com/aktnb/discord-bot-go/internal/config"
@@ -31,6 +32,7 @@ import (
 	mahjongcmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/mahjong"
 	omikujicmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/omikuji"
 	pingcmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/ping"
+	versioncmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/version"
 	yamadacmd "github.com/aktnb/discord-bot-go/internal/infrastructure/discord/commands/yamada"
 	"github.com/aktnb/discord-bot-go/internal/infrastructure/dogapi"
 	"github.com/aktnb/discord-bot-go/internal/infrastructure/mahjongapi"
@@ -72,6 +74,11 @@ func main() {
 
 	// Command registry
 	registry := commands.NewCommandRegistry()
+
+	// Version command
+	versionService := versionapp.NewVersionService(version)
+	versionCmd := versioncmd.NewVersionCommand(versionService)
+	registry.Register(versionCmd)
 
 	// Ping command
 	pingService := ping.NewPingService()

--- a/internal/application/version/service.go
+++ b/internal/application/version/service.go
@@ -1,0 +1,15 @@
+package version
+
+import "context"
+
+type Service struct {
+	version string
+}
+
+func NewVersionService(version string) *Service {
+	return &Service{version: version}
+}
+
+func (s *Service) Version(ctx context.Context) (string, error) {
+	return s.version, nil
+}

--- a/internal/infrastructure/discord/commands/version/command.go
+++ b/internal/infrastructure/discord/commands/version/command.go
@@ -1,0 +1,49 @@
+package version
+
+import (
+	"context"
+	"log"
+
+	"github.com/aktnb/discord-bot-go/internal/application/version"
+	"github.com/bwmarrin/discordgo"
+)
+
+type VersionCommand struct {
+	service *version.Service
+}
+
+func NewVersionCommand(service *version.Service) *VersionCommand {
+	return &VersionCommand{service: service}
+}
+
+func (c *VersionCommand) Name() string {
+	return "version"
+}
+
+func (c *VersionCommand) ToDiscordCommand() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        c.Name(),
+		Description: "ボットのバージョンを表示します",
+	}
+}
+
+func (c *VersionCommand) Handle(ctx context.Context, s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	v, err := c.service.Version(ctx)
+	if err != nil {
+		log.Printf("Error handling version command: %v", err)
+		return err
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: v,
+		},
+	})
+	if err != nil {
+		log.Printf("Error responding to version: %v", err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
ビルド時に ldflags で設定したバージョン文字列（ボットのステータスに表示しているもの）を返す /version スラッシュコマンドを実装。

https://claude.ai/code/session_01X2vbiH6MhCrjsfpU66Rodb